### PR TITLE
Get GitLab project using /projects/all API

### DIFF
--- a/gitlab-client.js
+++ b/gitlab-client.js
@@ -85,11 +85,12 @@ GitlabClient.prototype.listUsers = function(search, privateToken, cb) {
 	}, cb);
 };
 
-GitlabClient.prototype.listAllProjects = function(privateToken, cb) {
+GitlabClient.prototype.listAllProjects = function(search, privateToken, cb) {
 	this.paginate({
 		url: this.url + 'projects/all',
 		qs: {
-			private_token: privateToken
+			private_token: privateToken,
+			search: search
 		}
 	}, cb);
 };

--- a/sinopia-gitlab.js
+++ b/sinopia-gitlab.js
@@ -120,7 +120,7 @@ SinopiaGitlab.prototype._getGitlabProject = function(packageName, cb) {
 	checkCache('project-' + packageName, null, 3600, function(key, extraParams, cb) {
 		self._getAdminToken(function(error, token) {
 			if(error) return cb(error);
-			self.gitlab.listProjects(packageName, token, function(error, results) {
+			self.gitlab.listAllProjects(packageName, token, function(error, results) {
 				if(error) return cb(error);
 				if(self.searchNamespaces) {
 					results = results.filter(function(project) {


### PR DESCRIPTION
If admin user is not a member of a project or project visibility is private, the project will not be listed using **/projects** endpoint. Using **/projects/all** admin can search by all projects. 
