### PR TITLE
Add more options to match gitlab project from package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ auth:
     gitlab_server: https://git.example.com
     gitlab_admin_username: admin
     gitlab_admin_password: password123
+    gitlab_use_scope_as_group: false        # Match scope as group (Default false)
+    gitlab_project_prefix: npm-             # Use this if you prefix your projects in gitlab
 
 packages:
   'prefix-*':

--- a/sinopia-gitlab.js
+++ b/sinopia-gitlab.js
@@ -86,6 +86,8 @@ function SinopiaGitlab(settings, params) {
 	this.adminUsername = settings.gitlab_admin_username;
 	this.adminPassword = settings.gitlab_admin_password;
 	this.searchNamespaces = settings.gitlab_namespaces || null;
+	this.useScopeAsGroup = settings.gitlab_use_scope_as_group || false;
+	this.projectPrefix = settings.gitlab_project_prefix || '';
 }
 
 SinopiaGitlab.prototype._getAdminToken = function(cb) {
@@ -120,14 +122,32 @@ SinopiaGitlab.prototype._getGitlabProject = function(packageName, cb) {
 	checkCache('project-' + packageName, null, 3600, function(key, extraParams, cb) {
 		self._getAdminToken(function(error, token) {
 			if(error) return cb(error);
+			var projectName;
+			var groupName;
+			var parts = packageName.split('/');
+			if (parts.length === 1) {
+				projectName = parts[0];
+			} else if (parts.length === 2) {
+				groupName = parts[0].replace('@', '');
+				projectName = parts[1];
+			} else {
+				return cb(new Error('Incorrect package name: ' + packageName));
+			}
+			if (self.projectPrefix) {
+				projectName = self.projectPrefix + projectName;
+			}
 			self.gitlab.listProjects(packageName, token, function(error, results) {
 				if(error) return cb(error);
 				if(self.searchNamespaces) {
 					results = results.filter(function(project) {
-						if(self.searchNamespaces.indexOf(project.namespace.path) === -1) {
-							return false;
+						if (self.useScopeAsGroup) {
+							return project.namespace.path === groupName;
 						} else {
-							return true;
+							if(self.searchNamespaces.indexOf(project.namespace.path) === -1) {
+								return false;
+							} else {
+								return true;
+							}
 						}
 					});
 				}


### PR DESCRIPTION
New options:

gitlab_use_scope_as_group: false   # Match scope as group (Default false)
gitlab_project_prefix: npm-             # Use this if you prefix your projects in gitlab

Then, you can use packages like **@mycompany/repo-name** and match in gitlab as:
- Group: mycompany
- Project: repo-name

or
- Group: ignored
- Project: repo-name

Also you can prefix the gitlab project name, useful sometimes to categorize project types inside a group.
